### PR TITLE
Support for running ProjectM cli for inputframe creation in parallel to main generation

### DIFF
--- a/docker/deforum-pytorch-trt/requirements.txt
+++ b/docker/deforum-pytorch-trt/requirements.txt
@@ -22,3 +22,6 @@ transformers==4.31.0
 onnx-graphsurgeon>=0.3.27
 polygraphy
 protobuf==3.20.3
+python-decouple
+mutagen
+diffusers

--- a/setup.py
+++ b/setup.py
@@ -87,7 +87,10 @@ _deps = [
     'torchsde>=0.2.5',
     'fastapi>=0.100.0',
     'diffusers==0.27.2',
-    'accelerate==0.29.3'
+    'accelerate==0.29.3',
+    'python-decouple>=3.8',
+    'mutagen>=1.47.0',
+    'diffusers>=0.27.2',
 ]
 
 # this is a lookup table with items like:
@@ -188,7 +191,8 @@ extras["dev"] = deps_list('torch',
                           'torchsde',
                           'fastapi',
                           'diffusers',
-                          'accelerate')
+                          'accelerate',
+                          )
 
 extras["cli"] = deps_list('torch',
                           'torchvision',
@@ -215,7 +219,10 @@ extras["cli"] = deps_list('torch',
                           # 'clip-interrogator',
                           # 'streamlit',
                           'torchsde',
-                          # 'fastapi')
+                          # 'fastapi',
+                          'python-decouple',
+                          'mutagen',
+                          'diffusers',
                           )
 
 setup(

--- a/src/deforum/generators/comfy_utils.py
+++ b/src/deforum/generators/comfy_utils.py
@@ -8,9 +8,8 @@ import torch
 import torchsde
 
 from deforum.generators.rng_noise_generator import randn_local
-from deforum.utils.constants import comfy_path, root_path
+from deforum.utils.constants import config, root_path
 from deforum.utils.logging_config import logger
-from deforum.utils.string_utils import str_to_bool
 
 
 
@@ -58,25 +57,14 @@ def ensure_comfy(custom_path=None):
         "https://github.com/XmYx/ComfyUI-AnimateDiff-Evolved",
         "https://github.com/FizzleDorf/ComfyUI_FizzNodes",
     ]
-
     comfy_submodule_folders = [url.split("/")[-1] for url in comfy_submodules]
+    comfy_path = custom_path or config.comfy_path
+    comfy_submodule_folder = os.path.join(comfy_path, "custom_nodes")   
 
-    comfy_path = os.environ.get("COMFY_PATH")
-    comfy_submodule_folder = os.path.join(comfy_path, "custom_nodes")
-    if custom_path is not None:
-        comfy_path = custom_path
-    else:
-
-        comfy_path = os.environ.get("COMFY_PATH")
-
-    comfy_update = str_to_bool(os.environ.get("COMFY_UPDATE", "False"))
-        
-    comfy_submodule_folder = os.path.join(comfy_path, "custom_nodes")
-
-    if not os.path.exists(comfy_path):
+    if not os.path.exists(config.comfy_path):
         # Clone the comfy repository if it doesn't exist
         clone_repo_to("https://github.com/comfyanonymous/ComfyUI", comfy_path)
-    elif comfy_update:
+    elif config.comfy_update:
         # If comfy directory exists, update it.
         with change_dir(comfy_path):
             subprocess.run(["git", "pull"])

--- a/src/deforum/pipeline_utils.py
+++ b/src/deforum/pipeline_utils.py
@@ -10,7 +10,7 @@ from deforum.utils.logging_config import logger
 from .pipelines.deforum_animation.animation_params import (DeforumArgs, DeforumAnimArgs,
                                                            ParseqArgs, LoopArgs, RootArgs,
                                                            DeforumOutputArgs, DeforumAnimPrompts, areas)
-from .utils.constants import root_path
+from .utils.constants import config
 
 
 def next_seed(args, root):
@@ -189,9 +189,9 @@ class DeforumGenerationObject(DeforumDataObject):
         animation_prompts = DeforumAnimPrompts()
         self.animation_prompts = json.loads(animation_prompts)
         self.timestring = time.strftime('%Y%m%d%H%M%S')
-        self.batch_name = f"deforum_{self.timestring}"
+        self.batch_name = kwargs['batch_name'] or f"deforum_{self.timestring}"
         # current_arg_list = [deforum.args, deforum.anim_args, deforum.video_args, deforum.parseq_args]
-        full_base_folder_path = os.path.join(root_path, "output/deforum")
+        full_base_folder_path = config.output_dir
         self.raw_batch_name = self.batch_name
         # self.batch_name = substitute_placeholders(deforum.args.batch_name, current_arg_list,
         #                                                  full_base_folder_path)

--- a/src/deforum/pipelines/animatediff_animation/pipeline_animatediff_animation.py
+++ b/src/deforum/pipelines/animatediff_animation/pipeline_animatediff_animation.py
@@ -9,7 +9,7 @@ import torch
 
 from ..deforum_pipeline import DeforumBase
 from deforum.pipeline_utils import DeforumGenerationObject, extract_values
-from deforum.utils.constants import comfy_path
+from deforum.utils.constants import config
 from deforum.utils.video_save_util import save_as_h264
 from deforum.utils.logging_config import logger
 
@@ -64,7 +64,7 @@ class DeforumAnimateDiffPipeline(DeforumBase):
         super().__init__()
         self.generator = generator
         self.logger = logger
-        self.animatediff_path = os.path.join(comfy_path, "custom_nodes", "ComfyUI-AnimateDiff-Evolved")
+        self.animatediff_path = os.path.join(config.comfy_path, "custom_nodes", "ComfyUI-AnimateDiff-Evolved")
         sys.path.append(self.animatediff_path)
         from animatediff import sampling
 

--- a/src/deforum/pipelines/deforum_animation/pipeline_deforum_animation.py
+++ b/src/deforum/pipelines/deforum_animation/pipeline_deforum_animation.py
@@ -49,7 +49,7 @@ from ..deforum_pipeline import DeforumBase
 from ... import ComfyDeforumGenerator
 from ...models import DepthModel, RAFT
 from ...pipeline_utils import DeforumGenerationObject, pairwise_repl, isJson
-from ...utils.constants import root_path, other_model_dir
+from ...utils.constants import root_path, config 
 from ...utils.deforum_hybrid_animation import hybrid_generation
 from ...utils.deforum_logger_util import Logger
 from ...utils.image_utils import load_image_with_mask, prepare_mask, check_mask_for_errors, load_image
@@ -226,7 +226,7 @@ class DeforumAnimationPipeline(DeforumBase):
             # device = ('cpu' if cmd_opts.lowvram or cmd_opts.medvram else self.root.device)
             # TODO Set device in root in webui
             device = "cuda"
-            self.depth_model = DepthModel(other_model_dir, device, self.gen.half_precision,
+            self.depth_model = DepthModel(config.other_model_dir, device, self.gen.half_precision,
                                      keep_in_vram=self.gen.keep_in_vram,
                                      depth_algorithm=self.gen.depth_algorithm, Width=self.gen.width,
                                      Height=self.gen.height,

--- a/src/deforum/utils/blocking_file_list.py
+++ b/src/deforum/utils/blocking_file_list.py
@@ -1,0 +1,27 @@
+import os
+import time
+
+class BlockingFileList:
+    def __init__(self, base_directory, expected_file_count=0, extensions=["jpg", "png"], timeout_seconds=30):
+        self.base_directory = base_directory
+        self.expected_file_count = expected_file_count
+        self.extensions = extensions
+        self.timeout_seconds = timeout_seconds
+
+    def __getitem__(self, index):
+        start_time = time.time()
+        waited = 0
+
+        while waited < self.timeout_seconds:
+            for ext in self.extensions:
+                file_path = os.path.join(self.base_directory, f"{index}.{ext}")
+                if os.path.exists(file_path):
+                    return file_path
+            waited = time.time() - start_time
+            print(f"Could not find matching {self.extensions} file for index {index} in {self.base_directory}. Waited {waited:.2f}/{self.timeout_seconds}s...")
+            time.sleep(1)  # Wait for 1 second before checking again
+        
+        raise FileNotFoundError(f"No file with matching {self.extensions} file for index {index} in {self.base_directory} after waiting for {self.timeout_seconds} seconds")
+
+    def __len__(self):
+        return self.expected_file_count

--- a/src/deforum/utils/constants.py
+++ b/src/deforum/utils/constants.py
@@ -1,21 +1,40 @@
 import os
 import platform
+from dataclasses import dataclass
+from decouple import config
 
-root_path = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
 utils_dir = os.path.dirname(os.path.abspath(__file__))
-
 deforum_dir = os.path.dirname(utils_dir)
-
 src_dir = os.path.dirname(deforum_dir)
-
+root_path = os.path.dirname(src_dir)
 
 def get_os():
     return {"Windows": "Windows", "Linux": "Linux", "Darwin": "Mac"}.get(platform.system(), "Unknown")
 
 
-# root_path = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-comfy_path = os.path.join(src_dir, "ComfyUI")
+# Typesafe config data loaded from .env or .ini
+@dataclass
+class AppConfig:
+    comfy_path: str
+    model_dir: str
+    other_model_dir: str
+    output_dir: str
+    comfy_update: bool
+    allow_blocking_input_frame_lists: bool
+    projectm_docker_image: str
 
-model_dir = os.path.join(root_path, "models/checkpoints")
-other_model_dir = os.path.join(root_path, "models/other")
+    @staticmethod
+    def load():
+        return AppConfig(
+            comfy_path = config('COMFY_PATH', default=os.path.join(src_dir, "ComfyUI")),
+            model_dir = config('MODEL_PATH', default=os.path.join(root_path, "models")),
+            other_model_dir = config('OTHER_MODEL_PATH', default=os.path.join(root_path, "models/other")),
+            output_dir = config('OUTPUT_PATH', default=os.path.join(root_path, "output/deforum")),
+            comfy_update = config('COMFY_UPDATE', default=False, cast=bool),
+            allow_blocking_input_frame_lists = config('ALLOW_BLOCKING_INPUT_FRAME_LISTS', default=True, cast=bool),
+            projectm_docker_image = config('PROJECTM_DOCKER_IMAGE', default="rewbs/projectm-cli:0.0.4"),
+        )
+
+# Make available for import 
+config = AppConfig.load()

--- a/src/deforum/utils/deforum_hybrid_animation.py
+++ b/src/deforum/utils/deforum_hybrid_animation.py
@@ -6,6 +6,8 @@ import cv2
 import numpy as np
 from PIL import Image, ImageChops, ImageOps, ImageEnhance
 
+from deforum.utils.blocking_file_list import BlockingFileList
+
 from ..utils.deforum_human_masking import video2humanmasks
 from ..utils.image_utils import (get_resized_image_from_filename,
                                  autocontrast_grayscale,
@@ -14,6 +16,7 @@ from ..utils.video_frame_utils import (vid2frames,
                                        get_quick_vid_info,
                                        get_frame_name)
 from deforum.utils.logging_config import logger
+from deforum.utils.constants import config
 
 def delete_all_imgs_in_folder(folder_path):
     files = list(pathlib.Path(folder_path).glob('*.jpg'))
@@ -70,6 +73,10 @@ def hybrid_generation(args, anim_args, root):
     inputfiles = sorted(pathlib.Path(video_in_frame_path).glob('*.jpg'))
 
     if not anim_args.hybrid_use_init_image:
+        if config.allow_blocking_input_frame_lists:
+            logger.info(f"Will wait for input frames to appear in {video_in_frame_path}")
+            inputfiles = BlockingFileList(video_in_frame_path, anim_args.max_frames)
+                    
         # determine max frames from length of input frames
         if args.hybrid_use_full_video:
             anim_args.max_frames = len(inputfiles)

--- a/tests/test_audiovis_pipeline.py
+++ b/tests/test_audiovis_pipeline.py
@@ -1,0 +1,374 @@
+from deforum import DeforumAnimationPipeline
+import subprocess
+import threading
+import os
+import time
+import math
+from subprocess import Popen
+import mutagen
+from deforum.utils.constants import config
+from deforum.utils.logging_config import logger
+
+def run_projectm(input_audio: str, host_output_path : str, preset: str = 'ORB - Chop chop.milk', fps: int = 20, width: int = 1024, height: int = 576) -> Popen[bytes]:
+
+    logger.info(f"Starting projectM. Writing frames to: {host_output_path}")
+
+    assert os.path.exists(input_audio) and os.path.isfile(input_audio)
+    assert os.path.exists(host_output_path) and os.path.isdir(host_output_path)
+
+    # get directory of input audio
+    host_input_path = os.path.dirname(input_audio)
+
+    # get filename (without path) of input_audio
+    audio_filename = os.path.basename(input_audio)  
+
+    command = [
+        "docker", "run",
+        "-v", f"{host_input_path}:/input_dir",
+        "-v", f"{host_output_path}:/output_dir",
+        f"{config.projectm_docker_image}",
+        "--outputPath", "/output_dir/",
+        "--outputType", "image",
+        "--texturePath", "textures/textures",
+        "--width", f"{width}",
+        "--height", f"{height}",
+        "--beatSensitivity", "4.0",
+        "--fps", f"{fps}",
+        "--presetFile", f"presets_all/{preset}",
+        "--audioPath", f"/input_dir/{audio_filename}"
+    ]
+
+    # Start the process (without blocking)
+    process = subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+
+    return process
+
+def monitor_projectm(process : Popen[bytes]):
+    while True:
+        logger.info("ProjectM running...")        
+        output = process.stdout.readline()
+        error = process.stderr.readline()        
+        if output:
+            logger.info("[PROJECTM - stdout] - " +  output.decode().strip())
+        if error:
+            logger.error("[PROJECTM - stderr] - " +  error.decode().strip())
+
+        if process.poll() is not None:
+            if process.returncode != 0:
+                output = process.stdout.read()
+                error = process.stderr.read()
+            if output:
+                logger.info("[PROJECTM - stdout] - " +  output.decode().strip())
+            if error:
+                logger.error("[PROJECTM - stderr] - " +  error.decode().strip())
+                raise Exception("ProjectM exited with code {}".format(process.returncode))
+            else:
+                logger.info("ProjectM completed successfully")
+            break    
+
+        time.sleep(1) 
+
+
+def get_audio_duration(audio_file):
+    audio = mutagen.File(audio_file)
+    return audio.info.length
+
+
+if __name__ == "__main__":
+    preset = 'ORB - Chop chop.milk'
+    input_audio = "/home/rewbs/Rebound1_short.mp3"
+    fps = 20
+    width = 1024
+    height = 576
+    expected_frame_count = math.floor(fps * get_audio_duration(input_audio))
+    output_name = f"deforum_{time.strftime('%Y%m%d%H%M%S')}"
+    hybrid_frame_path = os.path.join(config.output_dir, output_name, "inputframes")
+
+    os.makedirs(hybrid_frame_path, exist_ok=True)
+    
+
+    # Start projectM and monitor it on a background thread.
+    projectm_process = run_projectm(
+        input_audio = input_audio,
+        host_output_path = hybrid_frame_path,
+        preset = preset,
+        fps = fps
+    )
+    thread = threading.Thread(target=monitor_projectm, args=(projectm_process,))
+    thread.start()
+
+    # Run Deforum pipeline on main thread while projectM runs in the background
+    pipeline = DeforumAnimationPipeline.from_civitai("125703")
+
+    args = {
+        "width": width,
+        "height": height,
+        "show_info_on_ui": True,
+        "tiling": False,
+        "restore_faces": False,
+        "seed_resize_from_w": 0,
+        "seed_resize_from_h": 0,
+        "seed": 10,
+        "sampler": "DPM++ SDE Karras",
+        "steps": 18,
+        "batch_name": output_name,
+        "seed_behavior": "fixed",
+        "seed_iter_N": 1,
+        "use_init": False,
+        "strength": 0.8,
+        "strength_0_no_init": True,
+        "init_image": "https://deforum.github.io/a1/I1.png",
+        "use_mask": False,
+        "use_alpha_as_mask": False,
+        "mask_file": "https://deforum.github.io/a1/M1.jpg",
+        "invert_mask": False,
+        "mask_contrast_adjust": 1.0,
+        "mask_brightness_adjust": 1.0,
+        "overlay_mask": True,
+        "mask_overlay_blur": 4,
+        "fill": 1,
+        "full_res_mask": True,
+        "full_res_mask_padding": 4,
+        "reroll_blank_frames": "ignore",
+        "reroll_patience": 10.0,
+        "motion_preview_mode": False,
+        "prompts": {
+            "0": "eyeballs, mushrooms, dramatic framing, cinematic lighting, high quality professional photography, macrophotography, iris, corona, haze, ultra detailed, beautiful textures"
+        },
+        "animation_prompts_positive": "",
+        "animation_prompts_negative": "skull, nsfw, nude, ugly, blurry, boring, signature, logo, writing, face, woman, girl, child, person, man",
+        "animation_mode": "2D",
+        "max_frames": expected_frame_count,
+        "border": "replicate",
+        "angle": "0: (0)",
+        "zoom": "0:(1)",
+        "translation_x": "0: (0)",
+        "translation_y": "0: (0)",
+        "translation_z": "0: (1.75)",
+        "transform_center_x": "0: (0.5)",
+        "transform_center_y": "0: (0.5)",
+        "rotation_3d_x": "0: (0)",
+        "rotation_3d_y": "0: (0)",
+        "rotation_3d_z": "0: (0)",
+        "enable_perspective_flip": False,
+        "perspective_flip_theta": "0: (0)",
+        "perspective_flip_phi": "0: (0)",
+        "perspective_flip_gamma": "0: (0)",
+        "perspective_flip_fv": "0: (53)",
+        "noise_schedule": "0: (0)",
+        "strength_schedule": "0: (0.55)",
+        "contrast_schedule": "0: (1.0)",
+        "cfg_scale_schedule": "0: (7)",
+        "enable_steps_scheduling": False,
+        "steps_schedule": "0: (25)",
+        "fov_schedule": "0: (70)",
+        "aspect_ratio_schedule": "0: (1)",
+        "aspect_ratio_use_old_formula": False,
+        "near_schedule": "0: (200)",
+        "far_schedule": "0: (10000)",
+        "seed_schedule": "0:(s), 1:(-1), \"max_f-2\":(-1), \"max_f-1\":(s)",
+        "pix2pix_img_cfg_scale_schedule": "0:(1.5)",
+        "enable_subseed_scheduling": True,
+        "subseed_schedule": "0: (2)",
+        "subseed_strength_schedule": "0: ((0.350 * sin((120 / 240 * 3.141 * (t + 0) / 24))**1 + 0.55))",
+        "enable_sampler_scheduling": False,
+        "sampler_schedule": "0: (\"Euler a\")",
+        "use_noise_mask": False,
+        "mask_schedule": "0: (\"{video_mask}\")",
+        "noise_mask_schedule": "0: (\"{video_mask}\")",
+        "enable_checkpoint_scheduling": False,
+        "checkpoint_schedule": "0: (\"model1.ckpt\"), 100: (\"model2.safetensors\")",
+        "enable_clipskip_scheduling": False,
+        "clipskip_schedule": "0: (2)",
+        "enable_noise_multiplier_scheduling": True,
+        "noise_multiplier_schedule": "0: (1)",
+        "resume_from_timestring": False,
+        "resume_timestring": "",
+        "enable_ddim_eta_scheduling": False,
+        "ddim_eta_schedule": "0: (0)",
+        "enable_ancestral_eta_scheduling": False,
+        "ancestral_eta_schedule": "0: (1)",
+        "amount_schedule": "0: (0.1)",
+        "kernel_schedule": "0: (5)",
+        "sigma_schedule": "0: (1)",
+        "threshold_schedule": "0: (0)",
+        "color_coherence": "None",
+        "color_coherence_image_path": "",
+        "color_coherence_video_every_N_frames": 1,
+        "color_force_grayscale": False,
+        "legacy_colormatch": False,
+        "diffusion_cadence": 1,
+        "optical_flow_cadence": "None",
+        "cadence_flow_factor_schedule": "0: (1)",
+        "optical_flow_redo_generation": "None",
+        "redo_flow_factor_schedule": "0: (1)",
+        "diffusion_redo": "0",
+        "noise_type": "perlin",
+        "perlin_octaves": 4,
+        "perlin_persistence": 0.5,
+        "use_depth_warping": True,
+        "depth_algorithm": "Midas-3-Hybrid",
+        "midas_weight": 0.2,
+        "padding_mode": "border",
+        "sampling_mode": "bicubic",
+        "save_depth_maps": False,
+        "video_init_path": "",
+        "extract_nth_frame": 1,
+        "extract_from_frame": 0,
+        "extract_to_frame": -1,
+        "overwrite_extracted_frames": False,
+        "use_mask_video": False,
+        "video_mask_path": "https://deforum.github.io/a1/VM1.mp4",
+        "hybrid_comp_alpha_schedule": "0:(0.8)",
+        "hybrid_comp_mask_blend_alpha_schedule": "0:(0.5)",
+        "hybrid_comp_mask_contrast_schedule": "0:(1)",
+        "hybrid_comp_mask_auto_contrast_cutoff_high_schedule": "0:(100)",
+        "hybrid_comp_mask_auto_contrast_cutoff_low_schedule": "0:(0)",
+        "hybrid_flow_factor_schedule": "0:(1)",
+        "hybrid_generate_inputframes": False,
+        "hybrid_generate_human_masks": "None",
+        "hybrid_use_first_frame_as_init_image": True,
+        "hybrid_motion": "Optical Flow",
+        "hybrid_motion_use_prev_img": True,
+        "hybrid_flow_consistency": True,
+        "hybrid_consistency_blur": 16,
+        "hybrid_flow_method": "Farneback",
+        "hybrid_composite": "Normal",
+        "hybrid_use_init_image": False,
+        "hybrid_comp_mask_type": "None",
+        "hybrid_comp_mask_inverse": False,
+        "hybrid_comp_mask_equalize": "None",
+        "hybrid_comp_mask_auto_contrast": False,
+        "hybrid_comp_save_extra_frames": False,
+        "parseq_manifest": "https://firebasestorage.googleapis.com/v0/b/sd-parseq.appspot.com/o/rendered%2FGUWZvNjsIQOWlB5HVb2uT3vEg4u1%2Fdoc-740b93ac-d133-40f4-8da9-389567b84c21.json?alt=media&token=f5330153-327f-4a1f-abef-1425104de586",
+        "parseq_use_deltas": True,
+        "parseq_non_schedule_overrides": False,
+        "use_looper": False,
+        "init_images": "{\n    \"0\": \"https://deforum.github.io/a1/Gi1.png\",\n    \"max_f/4-5\": \"https://deforum.github.io/a1/Gi2.png\",\n    \"max_f/2-10\": \"https://deforum.github.io/a1/Gi3.png\",\n    \"3*max_f/4-15\": \"https://deforum.github.io/a1/Gi4.jpg\",\n    \"max_f-20\": \"https://deforum.github.io/a1/Gi1.png\"\n}",
+        "image_strength_schedule": "0:(0.75)",
+        "blendFactorMax": "0:(0.35)",
+        "blendFactorSlope": "0:(0.25)",
+        "tweening_frames_schedule": "0:(20)",
+        "color_correction_factor": "0:(0.075)",
+        "cn_1_overwrite_frames": True,
+        "cn_1_vid_path": "/home/rewbs/Lazerpart.mp4",
+        "cn_1_mask_vid_path": "",
+        "cn_1_enabled": False,
+        "cn_1_low_vram": False,
+        "cn_1_pixel_perfect": True,
+        "cn_1_module": "canny",
+        "cn_1_model": "diffusers_xl_canny_full [2b69fca4]",
+        "cn_1_weight": "0:(0.6)",
+        "cn_1_guidance_start": "0:(0.0)",
+        "cn_1_guidance_end": "0:(1.0)",
+        "cn_1_processor_res": 512,
+        "cn_1_threshold_a": 100,
+        "cn_1_threshold_b": 200,
+        "cn_1_resize_mode": "Inner Fit (Scale to Fit)",
+        "cn_1_control_mode": "ControlNet is more important",
+        "cn_1_loopback_mode": False,
+        "cn_2_overwrite_frames": True,
+        "cn_2_vid_path": "",
+        "cn_2_mask_vid_path": "",
+        "cn_2_enabled": False,
+        "cn_2_low_vram": False,
+        "cn_2_pixel_perfect": True,
+        "cn_2_module": "CLIP-ViT-H (IPAdapter)",
+        "cn_2_model": "ip-adapter-plus_sdxl_vit-h [bc449f62]",
+        "cn_2_weight": "0:(0.6)",
+        "cn_2_guidance_start": "0:(0.0)",
+        "cn_2_guidance_end": "0:(1)",
+        "cn_2_processor_res": 0.5,
+        "cn_2_threshold_a": 0.5,
+        "cn_2_threshold_b": 0.5,
+        "cn_2_resize_mode": "Inner Fit (Scale to Fit)",
+        "cn_2_control_mode": "ControlNet is more important",
+        "cn_2_loopback_mode": True,
+        "cn_3_overwrite_frames": True,
+        "cn_3_vid_path": "/home/rewbs/Lazerpart.mp4",
+        "cn_3_mask_vid_path": "",
+        "cn_3_enabled": False,
+        "cn_3_low_vram": False,
+        "cn_3_pixel_perfect": True,
+        "cn_3_module": "depth_zoe",
+        "cn_3_model": "sai_xl_depth_256lora [73ad23d1]",
+        "cn_3_weight": "0:(1)",
+        "cn_3_guidance_start": "0:(0.0)",
+        "cn_3_guidance_end": "0:(1.0)",
+        "cn_3_processor_res": 512,
+        "cn_3_threshold_a": 0.5,
+        "cn_3_threshold_b": 0.5,
+        "cn_3_resize_mode": "Inner Fit (Scale to Fit)",
+        "cn_3_control_mode": "ControlNet is more important",
+        "cn_3_loopback_mode": False,
+        "cn_4_overwrite_frames": True,
+        "cn_4_vid_path": "",
+        "cn_4_mask_vid_path": "",
+        "cn_4_enabled": False,
+        "cn_4_low_vram": False,
+        "cn_4_pixel_perfect": False,
+        "cn_4_module": "none",
+        "cn_4_model": "None",
+        "cn_4_weight": "0:(1)",
+        "cn_4_guidance_start": "0:(0.0)",
+        "cn_4_guidance_end": "0:(1.0)",
+        "cn_4_processor_res": 64,
+        "cn_4_threshold_a": 64,
+        "cn_4_threshold_b": 64,
+        "cn_4_resize_mode": "Inner Fit (Scale to Fit)",
+        "cn_4_control_mode": "Balanced",
+        "cn_4_loopback_mode": False,
+        "cn_5_overwrite_frames": True,
+        "cn_5_vid_path": "",
+        "cn_5_mask_vid_path": "",
+        "cn_5_enabled": False,
+        "cn_5_low_vram": False,
+        "cn_5_pixel_perfect": False,
+        "cn_5_module": "none",
+        "cn_5_model": "None",
+        "cn_5_weight": "0:(1)",
+        "cn_5_guidance_start": "0:(0.0)",
+        "cn_5_guidance_end": "0:(1.0)",
+        "cn_5_processor_res": 64,
+        "cn_5_threshold_a": 64,
+        "cn_5_threshold_b": 64,
+        "cn_5_resize_mode": "Inner Fit (Scale to Fit)",
+        "cn_5_control_mode": "Balanced",
+        "cn_5_loopback_mode": False,
+        "freeu_enabled": True,
+        "freeu_b1": "0:(1.3)",
+        "freeu_b2": "0:(1.4)",
+        "freeu_s1": "0:(0.9)",
+        "freeu_s2": "0:(0.2)",
+        "kohya_hrfix_enabled": True,
+        "kohya_hrfix_block_number": "0:(1)",
+        "kohya_hrfix_downscale_factor": "0:(2.0)",
+        "kohya_hrfix_start_percent": "0:(0.0)",
+        "kohya_hrfix_end_percent": "0:(0.35)",
+        "kohya_hrfix_downscale_after_skip": True,
+        "kohya_hrfix_downscale_method": "bicubic",
+        "kohya_hrfix_upscale_method": "bicubic",
+        "skip_video_creation": False,
+        "fps": 20,
+        "make_gif": False,
+        "delete_imgs": False,
+        "delete_input_frames": False,
+        "add_soundtrack": "File",
+        "soundtrack_path": "/home/rewbs/Rebound1.mp3",
+        "r_upscale_video": False,
+        "r_upscale_factor": "x2",
+        "r_upscale_model": "realesr-animevideov3",
+        "r_upscale_keep_imgs": True,
+        "store_frames_in_ram": False,
+        "frame_interpolation_engine": "FILM",
+        "frame_interpolation_x_amount": 3,
+        "frame_interpolation_slow_mo_enabled": False,
+        "frame_interpolation_slow_mo_amount": 2,
+        "frame_interpolation_keep_imgs": True,
+        "frame_interpolation_use_upscaled": False,
+        "sd_model_name": "protovisionxl.safetensors",
+        "sd_model_hash": "81b8e089",
+        "deforum_git_commit_id": "Unknown"
+    }
+
+    pipeline(**args)


### PR DESCRIPTION
- Add test pipeline for audio vis which kicks off projectM in parallel to generation.
- Add typesafe config structure which can optionally read from a .env file (and has sensible defaults).
- Add blocking file list support for hybrid videos.

`test_audiovis_pipeline.py` shows an example of invoking projectM in parallel to the main generation. The projectM CLI is available on dockerhub at https://hub.docker.com/repository/docker/rewbs/projectm-cli .  It is a private repo but if you give me your dockerhub usernames I can add you.

(You will need to be able to run docker as your current user without sudo, and run `docker pull rewbs/projectm-cli:0.0.4` .)

