### PR TITLE
Improve audio merging to support a1111 settings format + other small improvements

### DIFF
--- a/src/deforum/pipeline_utils.py
+++ b/src/deforum/pipeline_utils.py
@@ -193,14 +193,12 @@ class DeforumGenerationObject(DeforumDataObject):
 
         self.timestring = kwargs.get('timestring', time.strftime('%Y%m%d%H%M%S'))
         self.batch_name = kwargs.get('batch_name', f"deforum_")
-        # current_arg_list = [deforum.args, deforum.anim_args, deforum.video_args, deforum.parseq_args]
         full_base_folder_path = config.output_dir
-        self.raw_batch_name = self.batch_name
-        # self.batch_name = substitute_placeholders(deforum.args.batch_name, current_arg_list,
-        #                                                  full_base_folder_path)
+        # outdir is computed here, but may be overridden by client code if 'outdir' is specified in the settings.
+        # This ability to override is essential to ensure predictable output paths for the client.
+        # The override happens in DeforumGenerationObject.from_settings_file().
         self.outdir = os.path.join(full_base_folder_path, f"{self.batch_name}_{self.timestring}")
-
-        # os.makedirs(self.outdir, exist_ok=True)
+        
 
         # Handle seed initialization
         if self.seed == -1 or self.seed == "-1":

--- a/src/deforum/pipelines/deforum_animation/animation_helpers.py
+++ b/src/deforum/pipelines/deforum_animation/animation_helpers.py
@@ -1282,22 +1282,31 @@ def save_video_cls(cls):
     else:
         name = f'{cls.gen.batch_name}'
     output_filename_base = os.path.join(dir_path, name)
+    
     if cls.gen.frame_interpolation_engine != "None":
         cls.gen.fps = float(cls.gen.fps) * int(cls.gen.frame_interpolation_x_amount)
         if cls.gen.frame_interpolation_slow_mo_enabled:
             cls.gen.fps /= int(cls.gen.frame_interpolation_slow_mo_amount)
-    audio_path = None
-    if hasattr(cls.gen, 'video_init_path'):
-        audio_path = cls.gen.video_init_path
-    if hasattr(cls.gen, 'audio_path'):
-        if cls.gen.audio_path != "":
-            audio_path = cls.gen.audio_path
-    fps = getattr(cls.gen, "fps", 24)  # Using getattr to simplify fetching attributes with defaults
+    
+    
+    audio_path = None  
+    if getattr(cls.gen, 'add_soundtrack') == 'Init Video':
+        audio_path = getattr(cls.gen, 'video_init_path')
+    elif getattr(cls.gen, 'audio_path'):
+        # prioritise new audio_path attribute (not supported in a1111 extension)
+        audio_path = getattr(cls.gen, 'audio_path')
+    elif getattr(cls.gen, 'add_soundtrack') == 'File':
+        # compatibility with a1111 extension, which expects "soundtrack_path"
+        # and only honours it if add_soundtrack == 'File'.
+        audio_path = getattr(cls.gen, 'soundtrack_path')
+
+    fps = getattr(cls.gen, "fps", 24)
+
     try:
-        save_as_h264(cls.images, output_filename_base + ".mp4", audio_path=audio_path, fps=fps)
+        cls.gen.video_path = save_as_h264(cls.images, output_filename_base + ".mp4", audio_path=audio_path, fps=fps)
     except Exception as e:
         logger.error(f"save as h264 failed: {str(e)}")
-    cls.gen.video_path = output_filename_base + ".mp4"
+     
 
 
 def calculate_frames_to_add(total_frames: int, interp_x: float) -> int:

--- a/src/deforum/pipelines/deforum_animation/pipeline_deforum_animation.py
+++ b/src/deforum/pipelines/deforum_animation/pipeline_deforum_animation.py
@@ -315,7 +315,7 @@ class DeforumAnimationPipeline(DeforumBase):
         self.shoot_fns.append(get_generation_params)
 
         self.gen.turbo_steps = self.gen.get('diffusion_cadence', 1)
-        if self.gen.turbo_steps > 1 and self.gen.optical_flow_cadence is not 'None':
+        if self.gen.turbo_steps > 1 and self.gen.optical_flow_cadence != 'None':
             self.shoot_fns.append(generate_interpolated_frames)
         if self.gen.color_coherence == 'Video Input' and hybrid_available:
             self.shoot_fns.append(color_match_video_input)
@@ -369,7 +369,7 @@ class DeforumAnimationPipeline(DeforumBase):
         if hasattr(self.gen, "deforum_save_gen_info_as_srt"):
             if self.gen.deforum_save_gen_info_as_srt:
                 self.shoot_fns.append(cls_subtitle_handler)
-        if self.gen.frame_interpolation_engine is not "None":
+        if self.gen.frame_interpolation_engine != "None":
             if self.gen.max_frames > 3:
                 if self.gen.frame_interpolation_engine == "FILM":
                     self.post_fns.append(film_interpolate_cls)

--- a/src/deforum/pipelines/deforum_animation/pipeline_deforum_animation.py
+++ b/src/deforum/pipelines/deforum_animation/pipeline_deforum_animation.py
@@ -427,7 +427,6 @@ class DeforumAnimationPipeline(DeforumBase):
                         new_outdir = os.path.join(parent_dir,
                                                   f"{os.path.basename(self.gen.resume_path)}_v{next_version}")
 
-                    # Your subsequent code for using new_outdir
                     os.makedirs(new_outdir, exist_ok=True)
                     image_files = sorted(glob(os.path.join(self.gen.resume_path, '*.png')), key=numeric_key)
                     files_to_copy = image_files[:resume_from]

--- a/src/deforum/ui/qt_modules/main_window.py
+++ b/src/deforum/ui/qt_modules/main_window.py
@@ -1338,7 +1338,7 @@ class MainWindow(DeforumCore):
 
     def generateViz(self, data):
         if self.params['generate_viz']:
-            if self.params['audio_path'] is not "":
+            if self.params['audio_path']:
                 milk = os.path.join(config.root_path, 'milks', self.params["milk_path"])
                 # print(milk)
 

--- a/src/deforum/utils/logging_config.py
+++ b/src/deforum/utils/logging_config.py
@@ -14,6 +14,7 @@ def setup_file_logging(log_file, log_level, log_max_bytes, log_backup_count):
         retention=log_backup_count,
         backtrace=True,
         diagnose=True,
+        enqueue=True
     )
 
 def setup_console_logging(log_level):
@@ -23,6 +24,7 @@ def setup_console_logging(log_level):
         format="<green>{time:YYYY-MM-DD HH:mm:ss.SSS}</green> - <cyan>{file}:{line}</cyan> - <lvl>{level}</lvl> - <lvl>{message}</lvl>",
         backtrace=True,
         diagnose=True,
+        enqueue=True
     )
 
 def setup_logging():

--- a/src/deforum/utils/video_save_util.py
+++ b/src/deforum/utils/video_save_util.py
@@ -1,6 +1,7 @@
 import os
 import subprocess
 import time
+import tempfile
 import imageio
 import numpy as np
 from PIL import Image
@@ -20,40 +21,59 @@ def save_as_gif(frames, filename):
     )
 
 def save_as_h264(frames, filename, audio_path=None, fps=12):
-    if len(frames) > 0:
-        # Handle frames input either as paths or as numpy arrays
-        if isinstance(frames[0], str):
-            frames = [Image.open(frame_path) for frame_path in frames]
-        elif isinstance(frames[0], np.ndarray):
-            frames = [Image.fromarray(frame) for frame in frames]
-        writer = imageio.get_writer(filename, fps=fps, codec='libx264',
-                                    pixelformat='yuv420p', output_params=['-crf', '5'])
-        for frame in frames:
-            writer.append_data(np.array(frame))
-        writer.close()
-        # audio_path = False
-        if audio_path:
-            try:
-                extracted_audio_path = "extracted_audio.aac"
-                # Transcode and extract audio to ensure compatibility
-                extract_cmd = ['ffmpeg', '-y', '-i', f'{audio_path}', '-vn', '-acodec', 'aac', '-strict', 'experimental',
-                               extracted_audio_path]
-                extract_process = subprocess.run(extract_cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
-                # Calculate the duration of the video
-                video_duration = len(frames) / fps
-                output_filename = filename.replace(".mp4", "_with_audio.mp4")
-                # Merge the extracted audio with the video file
-                merge_cmd = ['ffmpeg', '-y', '-i', filename, '-i', extracted_audio_path,
-                             '-c:v', 'copy', '-c:a', 'copy', '-strict', 'experimental',
-                             '-t', str(video_duration), output_filename]
-                merge_process = subprocess.run(merge_cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
-                if merge_process.returncode == 0:
-                    os.rename(output_filename, filename)  # Replace the original file with the merged audio version
-                    os.remove(extracted_audio_path)  # Cleanup the extracted audio file
-                    logger.info("Audio merged successfully.")
-            except subprocess.CalledProcessError as e:
-                logger.error(f"Audio processing failed: {e.stderr.decode('utf-8')}")
-            except Exception as e:
-                logger.error(f"An error occurred during audio merging: {str(e)}")
-    else:
-        logger.info("The buffer is empty, cannot save.")
+    if len(frames) <= 0:
+        logger.error("The buffer is empty, cannot save.")
+        return
+
+    # Handle frames input either as paths or as numpy arrays
+    if isinstance(frames[0], str):
+        frames = [Image.open(frame_path) for frame_path in frames]
+    elif isinstance(frames[0], np.ndarray):
+        frames = [Image.fromarray(frame) for frame in frames]
+    writer = imageio.get_writer(filename, fps=fps, codec='libx264', pixelformat='yuv420p', output_params=['-crf', '5'])
+    
+    for frame in frames:
+        writer.append_data(np.array(frame))
+    writer.close()
+
+    final_filename = filename
+    if audio_path:
+        try:
+            # audio_path could in fact be the init video so extract audio here. If audio_path 
+            extracted_audio_tmpfile = tempfile.NamedTemporaryFile(suffix=".aac").name
+            extract_cmd = ['ffmpeg', '-y', '-i', f'{audio_path}', '-vn', '-acodec', 'aac', '-strict', 'experimental', extracted_audio_tmpfile]
+            logger.debug(f"Audio extraction command: {' '.join(extract_cmd)}")
+            extract_process = subprocess.run(extract_cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+            if extract_process.returncode != 0:
+                logger.error(f"Audio extraction failed: {extract_process.stderr}")
+                return
+
+            # Calculate the duration of the video
+            video_duration = len(frames) / fps
+
+            # Merge the extracted audio with the video file
+            output_filename = filename.replace(".mp4", "_with_audio.mp4")                
+            merge_cmd = ['ffmpeg', '-y', '-i', filename, '-i', extracted_audio_tmpfile,
+                            '-c:v', 'copy', '-c:a', 'copy', '-strict', 'experimental',
+                            '-t', str(video_duration), output_filename]
+            logger.debug(f"Audio merge command: {' '.join(merge_cmd)}")
+            merge_process = subprocess.run(merge_cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+            if merge_process.returncode == 0:
+                os.rename(output_filename, filename)  # Replace the original file with the merged audio version
+                os.remove(extracted_audio_tmpfile)  # Cleanup the extracted audio file
+                logger.info("Audio merged successfully.")
+            else:
+                logger.error(f"Audio merging failed: {merge_process.stderr}")
+
+        except subprocess.CalledProcessError as e:
+            logger.error(f"Audio processing failed: {e.stderr.decode('utf-8')}")
+        except Exception as e:
+            logger.error(f"An error occurred during audio merging: {str(e)}")
+
+        finally:
+            if os.path.exists(extracted_audio_tmpfile):
+                os.remove(extracted_audio_tmpfile)
+        
+        final_filename = output_filename
+
+    return final_filename


### PR DESCRIPTION
Main change:
- Add support 'add_soundtrack' and 'soundtrack_path' settings as used by a1111 extension settings files.
-  Update cls.gen.video_path with path to video with audio if it is created.

Other changes:
- Slight refactoring and improved error handling in save_as_h264.
- Use equality comparison rather than identity check in a few places
- Tweak loguru config to use concurrent threads - this helps with some buffering issues I was seeing.