### PR TITLE
Automated test and lint

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -53,6 +53,7 @@ jobs:
 
     - name: Run pylint
       run: |
+        git-ratchet dump
         pylint --output-format=json --exit-zero src/deforum > reports/pylint_report.json
         pylint_count=$(jq length reports/pylint_report.json)
         echo "pylint,$pylint_count" > measures.csv
@@ -63,9 +64,10 @@ jobs:
 
     - name: Run ruff
       run: |
+        git-ratchet dump
         ruff check --exit-zero . > reports/ruff_report.txt
         ruff_count=$(cat reports/ruff_report.txt | grep \.py\: | wc -l)
-        echo "ruff,$ruff_count" > measures.csv
+        echo "ruff,$ruff_count" >> measures.csv
         git config --local user.email "action@github.com"
         git config --local user.name "GitHub Action"        
         git-ratchet check -v -w < measures.csv || (echo "Ruff issues have increased")

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,83 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - '**'
+  pull_request:
+    branches:
+      - '**'
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write  # allow action to write back to the git repo
+    strategy:
+      matrix:
+        python-version: [3.11]
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ matrix.python-version }}
+        cache: 'pip'
+
+    - name: 'Setup jq'
+      uses: dcarbone/install-jq-action@v2
+      with:
+        version: '1.7'
+        force: false
+
+    - name: 'Setup auto commit'
+      uses: stefanzweifel/git-auto-commit-action@v5
+      with:
+        commit_message: "Auto commit by GitHub Action"
+        commit_options: '--no-verify'
+        commit_user_name: 'GitHub Action'
+
+    - name: Download and install git-ratchet
+      run: |
+        sudo curl -L https://github.com/iangrunert/git-ratchet/releases/download/v0.3.2/linux_amd64_git-ratchet -o /usr/local/bin/git-ratchet
+        sudo chmod a+x /usr/local/bin/git-ratchet
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -e .['dev']
+        mkdir -p reports/
+
+    - name: Run pylint
+      run: |
+        pylint --output-format=json --exit-zero src/deforum > reports/pylint_report.json
+        pylint_count=$(jq length reports/pylint_report.json)
+        echo "pylint,$pylint_count" > measures.csv
+        git config --local user.email "action@github.com"
+        git config --local user.name "GitHub Action"        
+        git-ratchet check -v -w < measures.csv || (echo "Pylint issues have increased")
+        git-ratchet dump
+
+    - name: Run ruff
+      run: |
+        ruff check --exit-zero . > reports/ruff_report.txt
+        ruff_count=$(cat reports/ruff_report.txt | grep \.py\: | wc -l)
+        echo "ruff,$ruff_count" > measures.csv
+        git config --local user.email "action@github.com"
+        git config --local user.name "GitHub Action"        
+        git-ratchet check -v -w < measures.csv || (echo "Ruff issues have increased")
+        git-ratchet dump
+
+    - name: Run tests with pytest
+      run: |
+        pytest unittests --junitxml=reports/junit.xml
+      continue-on-error: false        
+
+    - name: Upload reports
+      uses: actions/upload-artifact@v2
+      with:
+        name: reports
+        path: reports

--- a/.pylintrc
+++ b/.pylintrc
@@ -1,0 +1,11 @@
+[MASTER]
+persistent=yes
+
+[MESSAGES CONTROL]
+# Only very enable specific errors for now
+disable=all
+enable=E0602,E0606
+
+[REPORTS]
+reports=no
+evaluation=10.0 - ((float(5 * error + warning + refactor + convention) / statement) * 10)

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ This is a **non-exhaustive** list. See `src/deforum/utils/constants.py` for more
 
 ## Unit testing
 
-These tests will ultimately run in CI on every commit on free hardware, so NEVER add unit tests that require a GPU. Mock away!
+These tests run in CI on every commit on free hardware, so NEVER add unit tests that require a GPU. Mock away!
 
 ### Setup
 
@@ -92,6 +92,13 @@ You can verify that the paths are setup correctly by running `python tests/test_
 
 - Run `deforum run-all` for a full run of all settings files under `{PRESETS_PATH}/settings`.
 - Run `deforum test-e2e` for a full run of all settings files under `{PRESETS_PATH}/settings`, and compare results to a baseline (or create a new baseline if none exists).
+
+## Linting 
+
+We use `ruff` for formatting & basic linting, and `pylint` for a small number of checks that are not supported by ruff. See `pyproject.toml` and `.pylintrc` for their respective config.
+When working on the code, please set up your IDE accordingly to avoid build failures. 
+
+We currently have many linting issues to fix, but are using a ratcheting mechanism in CI to ensure the number does not increase.
 
 
 ## CLI Commands

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,20 @@
+[tool.ruff]
+line-length = 119
+
+[tool.ruff.lint]
+ignore = ["E501"]
+select = ["C", "E", "F", "I", "W"]
+
+[tool.ruff.lint.per-file-ignores]
+# Ignore import violations in all `__init__.py` files.
+"__init__.py" = ["E402", "F401", "F403", "F811"]
+
+[tool.ruff.lint.isort]
+lines-after-imports = 2
+known-first-party = ["deforum"]
+
+[tool.ruff.format]
+quote-style = "double"
+indent-style = "space"
+skip-magic-trailing-comma = false
+line-ending = "auto"

--- a/setup.py
+++ b/setup.py
@@ -107,8 +107,11 @@ _deps = [
     'qtpy==2.4.1',
     'pyqt6==6.5.0',
     'pyqt6-qt6==6.5.0',
-    'pyqtgraph==0.13.7'
-    'pytest>=8.2.0'
+    'pyqtgraph==0.13.7',
+    'pytest>=8.2.0',
+    'ruff>=0.4.4',
+    'pylint>=3.2.1',
+
 ]
 
 # this is a lookup table with items like:
@@ -231,7 +234,7 @@ install_requires = deps_list('torch',
                              'pyqtgraph'
                              )
 
-extras['dev'] = deps_list('pytest')
+extras['dev'] = deps_list('pytest', 'ruff', 'pylint')
 
 
 setup(

--- a/src/deforum/generators/deforum_flow_generator.py
+++ b/src/deforum/generators/deforum_flow_generator.py
@@ -348,8 +348,13 @@ import numpy as np
 import cv2
 
 # Compute gradients
-sobel_x = torch.tensor([[[[-1, 0, 1], [-2, 0, 2], [-1, 0, 1]]]], dtype=torch.float32).to('cuda')
-sobel_y = torch.tensor([[[[-1, -2, -1], [0, 0, 0], [1, 2, 1]]]], dtype=torch.float32).to('cuda')
+try:
+    sobel_x = torch.tensor([[[[-1, 0, 1], [-2, 0, 2], [-1, 0, 1]]]], dtype=torch.float32).to('cuda')
+    sobel_y = torch.tensor([[[[-1, -2, -1], [0, 0, 0], [1, 2, 1]]]], dtype=torch.float32).to('cuda')
+except Exception:
+    logger.exception("Could not create sobel kernels for optical flow computation. This most likely means you do not have CUDA device available.")
+    sobel_x = None
+    sobel_y = None
 
 @torch.inference_mode()
 def get_flow_from_images_Farneback_torch(i1, i2, preset="normal", last_flow=None, pyr_scale=0.5, levels=3, winsize=15,
@@ -638,7 +643,6 @@ def rel_flow_to_abs_flow(rel_flow, width, height):
     fx = rel_fx * (max_flow * width)
     fy = rel_fy * (max_flow * height)
     return np.dstack((fx, fy))
-
 
 
 def remap(img,

--- a/src/deforum/generators/deforum_flow_generator.py
+++ b/src/deforum/generators/deforum_flow_generator.py
@@ -352,7 +352,7 @@ try:
     sobel_x = torch.tensor([[[[-1, 0, 1], [-2, 0, 2], [-1, 0, 1]]]], dtype=torch.float32).to('cuda')
     sobel_y = torch.tensor([[[[-1, -2, -1], [0, 0, 0], [1, 2, 1]]]], dtype=torch.float32).to('cuda')
 except Exception:
-    logger.exception("Could not create sobel kernels for optical flow computation. This most likely means you do not have CUDA device available.")
+    logger.warning("Could not create sobel kernels for optical flow computation. This most likely means you do not have CUDA device available.")
     sobel_x = None
     sobel_y = None
 

--- a/src/deforum/generators/deforum_noise_generator.py
+++ b/src/deforum/generators/deforum_noise_generator.py
@@ -3,12 +3,18 @@ import math
 import cv2
 import numpy as np
 import torch
-from PIL import Image, ImageOps
+from PIL import ImageOps
 from torch.nn.functional import interpolate
+
 from deforum.utils.deforum_framewarp_utils import sample_to_cv2
 from deforum.utils.logging_config import logger
 
-deforum_noise_gen = torch.Generator(device='cuda')
+
+try:
+    deforum_noise_gen = torch.Generator(device='cuda')
+except Exception:
+    logger.warning("CUDA not available, falling back to CPU.")
+    deforum_noise_gen = torch.Generator(device='cpu')
 
 def rand_perlin_2d(shape, res, fade=lambda t: 6 * t ** 5 - 15 * t ** 4 + 10 * t ** 3):
     delta = (res[0] / shape[0], res[1] / shape[1])


### PR DESCRIPTION
NOTE: this PR builds on https://github.com/deforum-studio/deforum/pull/53 which should be merged first.

This PR includes:
- Config files for ruff and pylint. Pylint is currently used exclusively for uninitialised var checks since they are not checked for by ruff. We can choose to expand this or not.
- Git workflow to kick of lint and unit tests on every branch and PR.
- Ratcheting mechanism to fail build if number of pylint or ruff warnings increases.  This is not yet enforced.
- Fallbacks to prevent CUDA from being required just from importing files (else we need a GPU to run unit tests, which is not acceptable).